### PR TITLE
Handle behavior of multi-chapter adult works.

### DIFF
--- a/AO3downloader.lua
+++ b/AO3downloader.lua
@@ -114,7 +114,8 @@ local function performHttpsRequest(request)
             socketutil:reset_timeout()
             return response, status -- Exit if the request succeeds
         end
-
+        -- Add a sleep to prevent rate limiting.
+        socket.sleep(1)
     end
 
     return nil, "Failed to connect using available protocols"
@@ -348,6 +349,33 @@ function AO3Downloader:getWorkMetadata(work_id)
 
     local body = table.concat(response_body)
     local root = htmlparser.parse(body)
+
+    local caution_content = nil
+    -- view_adult doesn't actually always bypass the adult check on the base url, so we need to use the chapter url.
+    local caution = root:select("p.caution")
+    if #caution > 0 then
+        caution_content = caution[1]:getcontent()
+    end
+
+    if caution_content and string.find(caution_content, "This work could have adult content") then
+        -- Finds the link with 'view_adult' in the url. This is the working chapter link.
+        local adult = root:select(".actions > li > a[href*='view_adult']")[1].attributes.href
+        local adult_url = string.format("%s%s", getAO3URL(), adult)
+        -- This should probably be refactored later to reduce duplication.
+        request = {
+            url = adult_url,
+            method = "GET",
+            headers = headers,
+            sink = ltn12.sink.table(response_body),
+        }
+        response, status = performHttpsRequest(request)
+        if not response then
+            logger.dbg("Failed to fetch work metadata. Status:", status or "unknown error")
+            return nil, "Failed to fetch work metadata"
+        end
+        body = table.concat(response_body)
+        root = htmlparser.parse(body)
+    end
 
     -- Extract metadata
     local titleElement = root:select(".title")[1]


### PR DESCRIPTION
Thank you for this plugin! It's great. I did run into some issues with some multi-chapter adult works. It seems like AO3 doesn't obey the view_adult=true for the works url, so there's some weird extra logic needed to handle that case.

I'm basing the behavior on the FanficFare behavior, which just opens the link on the 'Proceed' button: https://github.com/JimmXinu/FanFicFare/blob/caf46ba421b0b158c0668995d0084bc9178b7998/fanficfare/adapters/base_otw_adapter.py#L158-L171
