### PR TITLE
Fix cookie parsing

### DIFF
--- a/AO3downloader.lua
+++ b/AO3downloader.lua
@@ -91,7 +91,7 @@ local function parseSetCookie(set_cookie_value)
         part = part:match("^%s*(.-)%s*$")
         -- Match key-value pairs or key-only values
         local name, value = part:match("([^=]+)=?(.*)")
-        if not isParameter(name) then
+        if not isParameter(name) and value ~= "" and value ~= nil then
             if current_cookie then
                 table.insert(cookies_values, current_cookie)
             end


### PR DESCRIPTION
Fixes cookie parsing by not storing cookies with no value. Seemed to result in a bunch of time cookies with no value being stored unnecessarily in the config file.