### PR TITLE
Add bookmark, mark for later and subscription support in fanfic_reader

### DIFF
--- a/AO3_downloader_client.lua
+++ b/AO3_downloader_client.lua
@@ -1001,6 +1001,320 @@ function AO3DownloaderClient:commentOnWork(comment_content, work_id, chapter_id)
     }
 end
 
+function AO3DownloaderClient:markForLaterWork(work_id, later_or_read)
+    logger.dbg("AO3Downloader.koplugin: Marking work. Work ID: " .. tostring(work_id))
+    local login_status = self:GetSessionStatus()
+    if not login_status.success then
+        return {
+            success = false,
+            error = T("Failed to check login status: %1", login_status.error or "unknown error"),
+        }
+    end
+
+    if not login_status.logged_in then
+        return {
+            success = false,
+            error = T("User must be logged in to mark work."),
+        }
+    end
+
+    local authenticity_token_request = self:requestAO3Token()
+
+    if not authenticity_token_request.success then
+        return {
+            success = false,
+            error = T("Failed to retrieve AO3 token for marking work: %1", authenticity_token_request.error or "unknown error"),
+        }
+    end
+
+    local authenticity_token = authenticity_token_request.token
+
+    -- Mark As Read True, Mark For Later False
+    local kudos_url = T("%1/works/%2/%3", getAO3URL(), work_id, later_or_read and "mark_as_read" or "mark_for_later")
+
+    local response_body = {}
+    local headers = HTTPQueryHandler:get_default_headers()
+    headers["Content-Type"] = "application/x-www-form-urlencoded"
+
+    local form_data = encodeHelper:generateParametersStringForm({
+        ["authenticity_token"] = authenticity_token,
+        ["_method"] = "patch"
+    })
+    headers["Content-Length"] = tostring(#form_data)
+
+
+    local request = {
+        url = kudos_url,
+        method = "POST",
+        headers = headers,
+        sink = ltn12.sink.table(response_body),
+        source = ltn12.source.string(form_data),
+    }
+
+    local request_result = HTTPQueryHandler:performHTTPRequest(request)
+
+    if request_result.status == 302 then
+        return {
+            success = true,
+        }
+    end
+
+    return {
+        success = false,
+        error = T("Failed to mark work. Status: %1", request_result.status or "unknown error"),
+    }
+end
+
+function AO3DownloaderClient:setWorkSubscription(work_id, subscription_id)
+    logger.dbg("AO3Downloader.koplugin: Setting subscription. Work ID: " .. tostring(work_id))
+
+    local login_status = self:GetSessionStatus()
+    if not login_status.success then
+        return {
+            success = false,
+            error = T("Failed to check login status: %1", login_status.error or "unknown error"),
+        }
+    end
+
+    if not login_status.logged_in then
+        return {
+            success = false,
+            error = T("User must be logged in to subscribe."),
+        }
+    end
+
+    local token_request = self:requestAO3Token()
+    if not token_request.success then
+        return {
+            success = false,
+            error = T("Failed to retrieve AO3 token: %1", token_request.error or "unknown error"),
+        }
+    end
+
+    local authenticity_token = token_request.token
+
+    local url
+    local form
+
+    if not subscription_id then
+        url = T("%1/users/%2/subscriptions", getAO3URL(), login_status.username)
+
+        form = encodeHelper:generateParametersStringForm({
+            ["authenticity_token"] = authenticity_token,
+            ["subscription[subscribable_id]"] = tostring(work_id),
+            ["subscription[subscribable_type]"] = "Work",
+        })
+    else
+        if not subscription_id then
+            return {
+                success = false,
+                error = T("Subscription ID required to unsubscribe."),
+            }
+        end
+
+        url = T("%1/users/%2/subscriptions/%3",
+            getAO3URL(),
+            login_status.username,
+            subscription_id
+        )
+
+        form = encodeHelper:generateParametersStringForm({
+            ["authenticity_token"] = authenticity_token,
+            ["_method"] = "delete",
+            ["subscription[subscribable_id]"] = tostring(work_id),
+            ["subscription[subscribable_type]"] = "Work",
+        })
+    end
+
+    local response_body = {}
+    local headers = HTTPQueryHandler:get_default_headers()
+    headers["Content-Type"] = "application/x-www-form-urlencoded; charset=UTF-8"
+    headers["Content-Length"] = tostring(#form)
+    headers["Accept"] = "application/json, text/javascript, */*; q=0.01"
+    headers["X-Requested-With"] = "XMLHttpRequest"
+    headers["X-CSRF-Token"] = authenticity_token
+
+    local request = {
+        url = url,
+        method = "POST",
+        headers = headers,
+        sink = ltn12.sink.table(response_body),
+        source = ltn12.source.string(form),
+    }
+
+    local result = HTTPQueryHandler:performHTTPRequest(request)
+
+    local response_text = table.concat(response_body)
+
+    if result.status == 201 then
+        local json = require("dkjson")
+        local decoded, _, err = json.decode(response_text)
+
+        if decoded then
+            return {
+                success = true,
+                subscription_id = tostring(decoded.item_id),
+            }
+        end
+
+        return {
+            success = true,
+        }
+    end
+    if result.status == 302 or result.status == 200 then
+        return {
+            success = true
+        }
+    end
+
+    return {
+        success = false,
+        error = T("Failed to update subscription. Status: %1", result.status or "unknown error"),
+    }
+end
+
+function AO3DownloaderClient:updateBookmark(work_id, bookmark_id, pseud_id, notes, tags, collections, private, rec)
+    logger.dbg("AO3Downloader.koplugin: Updating bookmark. Work ID: " .. tostring(work_id))
+
+    local login_status = self:GetSessionStatus()
+    if not login_status.success then
+        return {
+            success = false,
+            error = T("Failed to check login status: %1", login_status.error or "unknown error"),
+        }
+    end
+
+    if not login_status.logged_in then
+        return {
+            success = false,
+            error = T("User must be logged in to edit bookmarks."),
+        }
+    end
+
+    local token_request = self:requestAO3Token()
+    if not token_request.success then
+        return {
+            success = false,
+            error = T("Failed to retrieve AO3 token: %1", token_request.error or "unknown error"),
+        }
+    end
+
+    local authenticity_token = token_request.token
+
+    local url
+    local form_data = {
+        ["authenticity_token"] = authenticity_token,
+        ["bookmark[pseud_id]"] = tostring(pseud_id),
+        ["bookmark[bookmarker_notes]"] = notes or "",
+        ["bookmark[tag_string]"] = tags or "",
+        ["bookmark[collection_names]"] = collections or "",
+        ["bookmark[private]"] = private and "1" or "0",
+        ["bookmark[rec]"] = rec and "1" or "0",
+    }
+
+    if bookmark_id then
+        url = T("%1/bookmarks/%2", getAO3URL(), bookmark_id)
+        form_data["_method"] = "put"
+        form_data["commit"] = "Update"
+    else
+        url = T("%1/works/%2/bookmarks", getAO3URL(), work_id)
+        form_data["commit"] = "Create"
+    end
+
+    local form = encodeHelper:generateParametersStringForm(form_data)
+
+    local response_body = {}
+    local headers = HTTPQueryHandler:get_default_headers()
+    headers["Content-Type"] = "application/x-www-form-urlencoded; charset=UTF-8"
+    headers["Content-Length"] = tostring(#form)
+    headers["X-CSRF-Token"] = authenticity_token
+
+    local request = {
+        url = url,
+        method = "POST",
+        headers = headers,
+        sink = ltn12.sink.table(response_body),
+        source = ltn12.source.string(form),
+    }
+
+    local result = HTTPQueryHandler:performHTTPRequest(request)
+
+    if result.status == 302 or result.status == 200 then
+        return {
+            success = true,
+            bookmark_id = result.response_headers and result.response_headers["location"]:match("/bookmarks/(%d+)")
+        }
+    end
+
+    return {
+        success = false,
+        error = T("Failed to update bookmark. Status: %1", result.status or "unknown error"),
+    }
+end
+
+function AO3DownloaderClient:deleteBookmark(bookmark_id)
+    logger.dbg("AO3Downloader.koplugin: Deleting bookmark. Bookmark ID: " .. tostring(bookmark_id))
+
+    local login_status = self:GetSessionStatus()
+    if not login_status.success then
+        return {
+            success = false,
+            error = T("Failed to check login status: %1", login_status.error or "unknown error"),
+        }
+    end
+
+    if not login_status.logged_in then
+        return {
+            success = false,
+            error = T("User must be logged in to delete bookmarks."),
+        }
+    end
+
+    local token_request = self:requestAO3Token()
+    if not token_request.success then
+        return {
+            success = false,
+            error = T("Failed to retrieve AO3 token: %1", token_request.error or "unknown error"),
+        }
+    end
+
+    local authenticity_token = token_request.token
+
+    local url = T("%1/bookmarks/%2", getAO3URL(), bookmark_id)
+    local form_data = {
+        ["authenticity_token"] = authenticity_token,
+        ["_method"] = "delete"
+    }
+
+    local form = encodeHelper:generateParametersStringForm(form_data)
+
+    local response_body = {}
+    local headers = HTTPQueryHandler:get_default_headers()
+    headers["Content-Type"] = "application/x-www-form-urlencoded; charset=UTF-8"
+    headers["Content-Length"] = tostring(#form)
+    headers["X-CSRF-Token"] = authenticity_token
+
+    local request = {
+        url = url,
+        method = "POST",
+        headers = headers,
+        sink = ltn12.sink.table(response_body),
+        source = ltn12.source.string(form),
+    }
+
+    local result = HTTPQueryHandler:performHTTPRequest(request)
+
+    if result.status == 302 then
+        return {
+            success = true,
+        }
+    end
+
+    return {
+        success = false,
+        error = T("Failed to update bookmark. Status: %1", result.status or "unknown error"),
+    }
+end
 
 
 -- AO3WebParser
@@ -1402,6 +1716,11 @@ function AO3WebParser:parseWorkPage(root)
     local categoryElement = root:select(".category > ul > li > a")[1]
     local iswipElement = root:select("dt.status")[1]
 
+    -- Extract logged in metadata
+    local markedForLaterElement = root:select(".mark > form > button")[1]
+    local subscriptionFormElement = root:select(".subscribe > form")[1]
+    local bookmarkFormElement = root:select("#bookmark-form > form")[1]
+
     -- Extract additional metadata
     local fandomElement = root:select(".fandom > ul")[1]
     local publishedElement = root:select("dd.published")[1]
@@ -1528,6 +1847,11 @@ function AO3WebParser:parseWorkPage(root)
         or "Unknown chapters"
     local language = languageElement and encodeHelper:parseToCodepoints(languageElement:getcontent()) or "Unknown language"
 
+    -- Extract logged in metadata values
+    local markedForLater = markedForLaterElement ~= nil and encodeHelper:parseToCodepoints(markedForLaterElement:getcontent()) == "Mark as Read"
+    local subscriptionID = subscriptionFormElement and subscriptionFormElement.attributes and subscriptionFormElement.attributes.id:match("edit_subscription_(%d+)") or false
+    local bookmarkID = bookmarkFormElement and bookmarkFormElement.attributes and bookmarkFormElement.attributes.action:match("/bookmarks/(%d+)") or false
+
     -- Extract EPUB link
     local epub_link = nil
     for _, e in ipairs(epubElement) do
@@ -1576,6 +1900,9 @@ function AO3WebParser:parseWorkPage(root)
         rating = ratingElement and ratingElement:getcontent(),
         category = categoryElement and categoryElement:getcontent(),
         iswip = iswip,
+        markedForLater = markedForLater,
+        subscriptionID = subscriptionID,
+        bookmarkID = bookmarkID,
     }
 
     return work

--- a/AO3_downloader_client.lua
+++ b/AO3_downloader_client.lua
@@ -1899,7 +1899,7 @@ function AO3WebParser:parseWorkPage(root)
     local bookmarkContent = {}
 
     local bookmarkNotesElement = root:select("#bookmark_notes")[1]
-    bookmarkContent.notes = encodeHelper:parseFromHTML(bookmarkNotesElement:getcontent())
+    bookmarkContent.notes = encodeHelper:parseFromHTML(bookmarkNotesElement:getcontent()) or ""
 
     local bookmarkTagElement = root:select("#bookmark_tag_string")[1]
     bookmarkContent.tags = bookmarkTagElement and bookmarkTagElement.attributes and bookmarkTagElement.attributes.value or ""

--- a/AO3_downloader_client.lua
+++ b/AO3_downloader_client.lua
@@ -1905,6 +1905,23 @@ function AO3WebParser:parseWorkPage(root)
     local subscriptionID = subscriptionFormElement and subscriptionFormElement.attributes and subscriptionFormElement.attributes.id:match("edit_subscription_(%d+)") or false
     local bookmarkID = bookmarkFormElement and bookmarkFormElement.attributes and bookmarkFormElement.attributes.action:match("/bookmarks/(%d+)") or false
 
+    local bookmarkContent = {}
+
+    local bookmarkNotesElement = root:select("#bookmark_notes")[1]
+    bookmarkContent.notes = encodeHelper:parseFromHTML(bookmarkNotesElement:getcontent())
+
+    local bookmarkTagElement = root:select("#bookmark_tag_string")[1]
+    bookmarkContent.tags = bookmarkTagElement and bookmarkTagElement.attributes and bookmarkTagElement.attributes.value or ""
+
+    local bookmarkCollectionElement = root:select("#bookmark_collection_names")[1]
+    bookmarkContent.collections = bookmarkCollectionElement and bookmarkCollectionElement.attributes and bookmarkCollectionElement.attributes.value or ""
+
+    local bookmarkPrivElement = root:select("#bookmark_private")[1]
+    bookmarkContent.private = bookmarkPrivElement and bookmarkPrivElement.attributes and bookmarkPrivElement.attributes.checked=="checked" or false
+
+    local bookmarkRecElement = root:select("#bookmark_rec")[1]
+    bookmarkContent.rec = bookmarkRecElement and bookmarkRecElement.attributes and bookmarkRecElement.attributes.checked=="checked" or false
+
     -- Extract EPUB link
     local epub_link = nil
     for _, e in ipairs(epubElement) do
@@ -1956,6 +1973,7 @@ function AO3WebParser:parseWorkPage(root)
         markedForLater = markedForLater,
         subscriptionID = subscriptionID,
         bookmarkID = bookmarkID,
+        bookmarkContent = bookmarkContent
     }
 
     return work

--- a/AO3_downloader_client.lua
+++ b/AO3_downloader_client.lua
@@ -74,6 +74,16 @@ function encodeHelper:parseToCodepoints(str)
     return self:unescapeText(str)
 end
 
+function encodeHelper:parseFromHTML(str)
+    return encodeHelper:parseToCodepoints(
+                    str
+                        :gsub("<br%s*/?>", "\n") -- Replace <br> tags with new lines
+                        :gsub("</p>", "\n\n") -- Add double new lines for paragraph breaks
+                        :gsub("<[^>]+>", "") -- Remove other HTML tags
+                        :gsub("^%s*(.-)%s*$", "%1") -- Trim whitespace
+                )
+end
+
 function encodeHelper:generateParametersStringForm(params)
     local form_parts = {}
     for key, value in pairs(params) do
@@ -1514,12 +1524,7 @@ function AO3WebParser:parseUserSeriesPage(root)
             end
 
             local summaryElement = element:select(".summary")[1]
-            local summary = summaryElement and encodeHelper:parseToCodepoints(summaryElement:getcontent()
-                :gsub("<br%s*/?>", "\n") -- Replace <br> tags with new lines
-                :gsub("</p>", "\n\n") -- Add double new lines for paragraph breaks
-                :gsub("<[^>]+>", "") -- Remove other HTML tags
-                :gsub("^%s*(.-)%s*$", "%1") -- Trim whitespace) or ""
-            )
+            local summary = summaryElement and encodeHelper:parseFromHTML(summaryElement:getcontent())
 
             local wordCountElement = element:select("dd.words")[1]
             logger.dbg(wordCountElement and wordCountElement:getcontent():gsub(",", "") or "No word count element found")
@@ -1679,14 +1684,7 @@ function AO3WebParser:parseWorkElement(element)
 
         -- Remove HTML formatting, replace <br> with new lines, and preserve paragraph formatting
         local summary = summaryElement
-                and encodeHelper:parseToCodepoints(
-                    summaryElement
-                        :getcontent()
-                        :gsub("<br%s*/?>", "\n") -- Replace <br> tags with new lines
-                        :gsub("</p>", "\n\n") -- Add double new lines for paragraph breaks
-                        :gsub("<[^>]+>", "") -- Remove other HTML tags
-                        :gsub("^%s*(.-)%s*$", "%1") -- Trim whitespace
-                )
+            and encodeHelper:parseFromHTML(summaryElement:getcontent())
             or "No summary available"
 
         -- Remove leading and trailing whitespace from the title
@@ -1810,14 +1808,7 @@ function AO3WebParser:parseWorkPage(root)
     local gifted_to = giftElements and table.concat(giftedTo_table, ", ") or nil
 
     local summary = summaryElement
-        and encodeHelper:parseToCodepoints(
-            summaryElement
-            :getcontent()
-            :gsub("<br%s*/?>", "\n") -- Replace <br> tags with new lines
-            :gsub("</p>", "\n\n") -- Add double new lines for paragraph breaks
-            :gsub("<[^>]+>", "") -- Remove other HTML tags
-            :gsub("^%s*(.-)%s*$", "%1") -- Trim whitespace
-        )
+        and encodeHelper:parseFromHTML(summaryElement:getcontent())
         or "No summary available"
 
     local chapterData = {}

--- a/AO3_downloader_client.lua
+++ b/AO3_downloader_client.lua
@@ -1899,7 +1899,7 @@ function AO3WebParser:parseWorkPage(root)
     local bookmarkContent = {}
 
     local bookmarkNotesElement = root:select("#bookmark_notes")[1]
-    bookmarkContent.notes = encodeHelper:parseFromHTML(bookmarkNotesElement:getcontent()) or ""
+    bookmarkContent.notes = bookmarkNotesElement and encodeHelper:parseFromHTML(bookmarkNotesElement:getcontent()) or ""
 
     local bookmarkTagElement = root:select("#bookmark_tag_string")[1]
     bookmarkContent.tags = bookmarkTagElement and bookmarkTagElement.attributes and bookmarkTagElement.attributes.value or ""

--- a/AO3_downloader_client.lua
+++ b/AO3_downloader_client.lua
@@ -764,6 +764,49 @@ function AO3DownloaderClient:getUserPseuds(username)
     }
 end
 
+function AO3DownloaderClient:getAccountPseudID(username)
+    local url = T("%1/users/%2/pseuds/%2/edit", getAO3URL(), username)
+
+    local response_body = {}
+    local request = {
+        url = url,
+        method = "GET",
+        sink = ltn12.sink.table(response_body),
+    }
+
+    local request_result = HTTPQueryHandler:performHTTPRequest(request)
+
+    if request_result.status == 404 then
+        return {
+            success = false,
+            error = T("Pseud edit page for '%1' not found.", username),
+        }
+    end
+
+    if not request_result.success then
+        return {
+            success = false,
+            error = T("Failed to fetch accound pseud ID. Status: %1", request_result.status or "unknown error"),
+        }
+    end
+
+    local html_body = table.concat(response_body)
+    local root = htmlparser.parse(html_body)
+    local pseud_id = AO3WebParser:parseAccountPseudID(root)
+
+    if not pseud_id then
+        return {
+            success = false,
+            error = T("Failed to parse accound pseud ID"),
+        }
+    end
+
+    return {
+        success = true,
+        pseud_id = pseud_id,
+    }
+end
+
 function AO3DownloaderClient:searchForUsers(search_query, page_no)
     logger.dbg("AO3Downloader.koplugin: Executing user search for query: " .. tostring(search_query) .. ", page no: " .. tostring(page_no))
     if not search_query or search_query == "" then
@@ -1173,7 +1216,7 @@ function AO3DownloaderClient:setWorkSubscription(work_id, subscription_id)
     }
 end
 
-function AO3DownloaderClient:updateBookmark(work_id, bookmark_id, pseud_id, notes, tags, collections, private, rec)
+function AO3DownloaderClient:updateBookmark(work_id, bookmark_id, notes, tags, collections, private, rec)
     logger.dbg("AO3Downloader.koplugin: Updating bookmark. Work ID: " .. tostring(work_id))
 
     local login_status = self:GetSessionStatus()
@@ -1204,7 +1247,6 @@ function AO3DownloaderClient:updateBookmark(work_id, bookmark_id, pseud_id, note
     local url
     local form_data = {
         ["authenticity_token"] = authenticity_token,
-        ["bookmark[pseud_id]"] = tostring(pseud_id),
         ["bookmark[bookmarker_notes]"] = notes or "",
         ["bookmark[tag_string]"] = tags or "",
         ["bookmark[collection_names]"] = collections or "",
@@ -1219,6 +1261,17 @@ function AO3DownloaderClient:updateBookmark(work_id, bookmark_id, pseud_id, note
     else
         url = T("%1/works/%2/bookmarks", getAO3URL(), work_id)
         form_data["commit"] = "Create"
+
+        local pseud_result = AO3DownloaderClient:getAccountPseudID(login_status.username)
+
+        if not pseud_result.success then
+            return {
+                success = false,
+                error = T("Error: %1", pseud_result.error)
+            }
+        end
+
+        form_data["bookmark[pseud_id]"] = tostring(pseud_result.pseud_id)
     end
 
     local form = encodeHelper:generateParametersStringForm(form_data)
@@ -2057,6 +2110,15 @@ function AO3WebParser:parseUserPseuds(root)
     end
 
     return pseuds
+end
+
+function AO3WebParser:parseAccountPseudID(root)
+
+    local element = root:select(".edit_pseud")[1]
+
+    local pseud_id = element and element.attributes and element.attributes.id:match("edit_pseud_(%d+)") or false
+
+    return pseud_id
 end
 
 function AO3WebParser:parseUserSearchResults(root)

--- a/downloaded_fanfics_menu.lua
+++ b/downloaded_fanfics_menu.lua
@@ -175,7 +175,7 @@ function DownloadedFanficsMenu:show(ui, parentMenu, updateFanficCallback, Fanfic
                                                 callback = function()
                                                     -- Show detailed information
                                                     local details = string.format(
-                                                        "Fandoms: %s\n\nStatus: %s \nChapters: %s\nPublished: %s\nUpdated: %s\nAuthor: %s\n\nSummary:\n%s\n\nRating: %s\nCategory: %s\n\nTags:\nWarnings:\n%s\n\nRelationships:\n%s\n\nCharacters:\n%s\n\nOther Tags:\n%s\n\nStats: \nWords: %s \nHits: %s\nKudos: %s\nBookmarks: %s\nComments: %s",
+                                                        "Fandoms: %s\n\nStatus: %s \nChapters: %s\nPublished: %s\nUpdated: %s\nAuthor: %s\n\nSummary:\n%s\n\nRating: %s\nCategory: %s\n\nTags:\nWarnings:\n%s\n\nRelationships:\n%s\n\nCharacters:\n%s\n\nOther Tags:\n%s\n\nBookmarked: %s\nMarked for Later: %s\nSubscribed: %s\n\nStats: \nWords: %s \nHits: %s\nKudos: %s\nBookmarks: %s\nComments: %s",
                                                         (
                                                             #fanfic.fandoms > 0 and table.concat(fanfic.fandoms, ", ")
                                                             or "No fandoms available"
@@ -206,6 +206,9 @@ function DownloadedFanficsMenu:show(ui, parentMenu, updateFanficCallback, Fanfic
                                                             #fanfic.tags > 0 and table.concat(fanfic.tags, ", ")
                                                             or "No tags available"
                                                         ),
+                                                        fanfic.bookmarkID and "Yes (" .. tostring(fanfic.bookmarkID) ..")" or "No",
+                                                        fanfic.markedForLater and "Yes" or "No",
+                                                        fanfic.subscriptionID and "Yes (" .. fanfic.subscriptionID ..")" or "No",
                                                         fanfic.wordcount or "Unknown",
                                                         fanfic.hits or "0",
                                                         fanfic.kudos or "0",

--- a/fanfic_reader.lua
+++ b/fanfic_reader.lua
@@ -240,7 +240,6 @@ function FanficReader:addToMainMenu(menu_items)
                         local request_result = AO3DownloaderClient:updateBookmark(
                             self.current_fanfic.id,
                             self.current_fanfic.bookmarkID,
-                            "18388684",
                             fields[1],
                             fields[2],
                             fields[3],
@@ -282,9 +281,7 @@ function FanficReader:addToMainMenu(menu_items)
                         local request_result = AO3DownloaderClient:deleteBookmark(self.current_fanfic.bookmarkID)
 
                         if request_result.success then
-                            if request_result.bookmark_id then
-                                self.current_fanfic.bookmarkID = false
-                            end
+                            self.current_fanfic.bookmarkID = false
                             DownloadedFanfics.update(self.current_fanfic, false)
 
                             UIManager:show(InfoMessage:new({
@@ -297,7 +294,6 @@ function FanficReader:addToMainMenu(menu_items)
                         UIManager:show(InfoMessage:new({
                             text = "Error: " .. request_result.error,
                         }))
-
 
                         UIManager:close(bookmark_input)
                     end

--- a/fanfic_reader.lua
+++ b/fanfic_reader.lua
@@ -9,6 +9,7 @@ local AO3DownloaderClient = require("AO3_downloader_client")
 local InfoMessage = require("ui/widget/infomessage")
 local InputDialog = require("ui/widget/inputdialog")
 local ButtonDialog = require("ui/widget/buttondialog")
+local MultiInputDialog = require("ui/widget/multiinputdialog")
 
 local FFIUtil = require("ffi/util")
 local T = FFIUtil.template
@@ -182,37 +183,38 @@ function FanficReader:addToMainMenu(menu_items)
                                     return
                                 end
 
-                                local MultiInputDialog = require("ui/widget/multiinputdialog")
-                                local UIManager = require("ui/uimanager")
-                                local _ = require("gettext")
-
                                 local bookmark_input
+                                local bookmarkContent = {notes="",tags="",collections=""}
 
                                 local buttons = {
                                     {
-                                        text = _("Cancel"),
+                                        text = "Cancel",
                                         id = "close",
                                         callback = function()
                                             UIManager:close(bookmark_input)
                                         end
                                     },
                                     {
-                                        text = _(self.current_fanfic.bookmarkID and "Update" or "Create"),
+                                        text = self.current_fanfic.bookmarkID and "Update" or "Create",
                                         callback = function()
                                             local fields = bookmark_input:getFields()
+                                            bookmarkContent.private = fields[1] == "y" or fields[1] == "Y"
+                                            bookmarkContent.rec = fields[2] == "y" or fields[2] == "Y"
 
                                             local request_result = AO3DownloaderClient:updateBookmark(
                                                 self.current_fanfic.id,
                                                 self.current_fanfic.bookmarkID,
-                                                fields[1],
-                                                fields[2],
-                                                fields[3],
-                                                fields[4] == "y" or fields[4] == "Y",
-                                                fields[5] == "y" or fields[5] == "Y"
+                                                bookmarkContent.notes,
+                                                bookmarkContent.tags,
+                                                bookmarkContent.collections,
+                                                bookmarkContent.private,
+                                                bookmarkContent.rec
                                             )
 
                                             if request_result.success then
                                                 local originalBMID = self.current_fanfic.bookmarkID
+
+                                                self.current_fanfic.bookmarkContent = bookmarkContent
 
                                                 if request_result.bookmark_id then
                                                     self.current_fanfic.bookmarkID = request_result.bookmark_id
@@ -222,14 +224,11 @@ function FanficReader:addToMainMenu(menu_items)
                                                 UIManager:show(InfoMessage:new({
                                                     text = originalBMID and "Updated Bookmark" or "Created Bookmark",
                                                 }))
-
-                                                return
+                                            else
+                                                UIManager:show(InfoMessage:new({
+                                                    text = "Error: " .. request_result.error,
+                                                }))
                                             end
-
-                                            UIManager:show(InfoMessage:new({
-                                                text = "Error: " .. request_result.error,
-                                            }))
-
 
                                             UIManager:close(bookmark_input)
                                         end
@@ -238,57 +237,175 @@ function FanficReader:addToMainMenu(menu_items)
 
                                 if self.current_fanfic.bookmarkID then
                                     table.insert(buttons, {
-                                        text = _("Delete"),
+                                        text = "Delete",
                                         callback = function()
+                                            local confirmDialog
+                                            -- Confirm deletion
+                                            confirmDialog = ButtonDialog:new({
+                                                title = "Are you sure you want to delete this bookmark?",
+                                                buttons = {
+                                                    {
+                                                        {
+                                                            text = "Delete",
+                                                            callback = function()
+                                                                local request_result = AO3DownloaderClient:deleteBookmark(self.current_fanfic.bookmarkID)
 
-                                            local request_result = AO3DownloaderClient:deleteBookmark(self.current_fanfic.bookmarkID)
+                                                                if request_result.success then
+                                                                    self.current_fanfic.bookmarkID = false
+                                                                    self.current_fanfic.bookmarkContent = {}
+                                                                    DownloadedFanfics.update(self.current_fanfic, false)
 
-                                            if request_result.success then
-                                                self.current_fanfic.bookmarkID = false
-                                                self.current_fanfic.bookmarkContent = nil
-                                                DownloadedFanfics.update(self.current_fanfic, false)
+                                                                    UIManager:show(InfoMessage:new({
+                                                                        text = "Deleted Bookmark",
+                                                                    }))
+                                                                else
+                                                                    UIManager:show(InfoMessage:new({
+                                                                        text = "Error: " .. request_result.error,
+                                                                    }))
+                                                                end
 
-                                                UIManager:show(InfoMessage:new({
-                                                    text = "Deleted Bookmark",
-                                                }))
-
-                                                return
-                                            end
-
-                                            UIManager:show(InfoMessage:new({
-                                                text = "Error: " .. request_result.error,
-                                            }))
-
-                                            UIManager:close(bookmark_input)
+                                                                UIManager:close(confirmDialog)
+                                                                UIManager:close(bookmark_input)
+                                                            end,
+                                                        },
+                                                        {
+                                                            text = "Cancel",
+                                                            callback = function()
+                                                                UIManager:close(confirmDialog)
+                                                            end,
+                                                        },
+                                                    },
+                                                },
+                                            })
+                                            UIManager:show(confirmDialog)
                                         end
                                     })
+                                    if self.current_fanfic.bookmarkContent then
+                                        for k, v in pairs(self.current_fanfic.bookmarkContent) do
+                                            bookmarkContent[k] = v
+                                        end
+                                    end
                                 end
 
                                 bookmark_input = MultiInputDialog:new {
-                                    title = _(self.current_fanfic.bookmarkID and "Overwrite existing bookmark" or "Save a bookmark!"),
+                                    title = self.current_fanfic.bookmarkID and "Update existing bookmark" or "Save a bookmark!",
                                     fields = {
                                         {
-                                            hint = _("Notes"),
-                                            text = self.current_fanfic.bookmarkContent and self.current_fanfic.bookmarkContent.notes or nil
+                                            hint = "Y/N",
+                                            text = self.current_fanfic.bookmarkContent and (self.current_fanfic.bookmarkContent.private and "Y" or "N") or nil,
+                                            description = "Private bookmark"
                                         },
                                         {
-                                            hint = _("Your tags (Comma Seperated)"),
-                                            text = self.current_fanfic.bookmarkContent and self.current_fanfic.bookmarkContent.tags or nil
-                                        },
-                                        {
-                                            hint = _("Add to collections (Comma Seperated)"),
-                                            text = self.current_fanfic.bookmarkContent and self.current_fanfic.bookmarkContent.collections or nil
-                                        },
-                                        {
-                                            hint = _("Private bookmark (Y/N)"),
-                                            text = self.current_fanfic.bookmarkContent and (self.current_fanfic.bookmarkContent.private and "Y" or "N") or nil
-                                        },
-                                        {
-                                            hint = _("Rec (Y/N)"),
-                                            text = self.current_fanfic.bookmarkContent and (self.current_fanfic.bookmarkContent.rec and "Y" or "N") or nil
+                                            hint = "Y/N",
+                                            text = self.current_fanfic.bookmarkContent and (self.current_fanfic.bookmarkContent.rec and "Y" or "N") or nil,
+                                            description = "Rec"
                                         },
                                     },
                                     buttons = {
+                                        {
+                                            {
+                                                text = "Edit Notes",
+                                                callback = function()
+                                                    local notes_input
+                                                    notes_input = InputDialog:new {
+                                                        title = "Notes",
+                                                        input = bookmarkContent.notes or nil,
+                                                        fullscreen = true,
+                                                        condensed = true,
+                                                        allow_newline = true,
+                                                        add_scroll_buttons = true,
+                                                        buttons = {
+                                                            {
+                                                                {
+                                                                    text = "\u{f00d}",
+                                                                    id = "close",
+                                                                    callback = function()
+                                                                        UIManager:close(notes_input)
+                                                                    end,
+                                                                },
+                                                                {
+                                                                    text = "\u{f00c}",
+                                                                    callback = function()
+                                                                        bookmarkContent.notes = notes_input:getInputText()
+                                                                        UIManager:close(notes_input)
+                                                                    end,
+                                                                },
+                                                            }
+                                                        },
+                                                    }
+                                                    UIManager:show(notes_input)
+                                                    notes_input:onShowKeyboard()
+                                                end
+                                            },
+                                        },
+                                        {
+                                            {
+                                                text = "Edit Tags",
+                                                callback = function()
+                                                    local tags_input
+                                                    tags_input = InputDialog:new {
+                                                        title = "Your tags (Comma Seperated)",
+                                                        input = bookmarkContent.tags or nil,
+                                                        fullscreen = true,
+                                                        condensed = true,
+                                                        add_scroll_buttons = true,
+                                                        buttons = {
+                                                            {
+                                                                {
+                                                                    text = "\u{f00d}",
+                                                                    id = "close",
+                                                                    callback = function()
+                                                                        UIManager:close(tags_input)
+                                                                    end,
+                                                                },
+                                                                {
+                                                                    text = "\u{f00c}",
+                                                                    callback = function()
+                                                                        bookmarkContent.tags = tags_input:getInputText()
+                                                                        UIManager:close(tags_input)
+                                                                    end,
+                                                                },
+                                                            }
+                                                        },
+                                                    }
+                                                    UIManager:show(tags_input)
+                                                    tags_input:onShowKeyboard()
+                                                end
+                                            },
+                                            {
+                                                text = "Edit Collections",
+                                                callback = function()
+                                                    local collections_input
+                                                    collections_input = InputDialog:new {
+                                                        title = "Add to collections (Comma Seperated)",
+                                                        input = bookmarkContent.collections or nil,
+                                                        fullscreen = true,
+                                                        condensed = true,
+                                                        add_scroll_buttons = true,
+                                                        buttons = {
+                                                            {
+                                                                {
+                                                                    text = "\u{f00d}",
+                                                                    id = "close",
+                                                                    callback = function()
+                                                                        UIManager:close(collections_input)
+                                                                    end,
+                                                                },
+                                                                {
+                                                                    text = "\u{f00c}",
+                                                                    callback = function()
+                                                                        bookmarkContent.collections = collections_input:getInputText()
+                                                                        UIManager:close(collections_input)
+                                                                    end,
+                                                                },
+                                                            }
+                                                        },
+                                                    }
+                                                    UIManager:show(collections_input)
+                                                    collections_input:onShowKeyboard()
+                                                end
+                                            }
+                                        },
                                         buttons
                                     },
                                 }

--- a/fanfic_reader.lua
+++ b/fanfic_reader.lua
@@ -143,6 +143,195 @@ function FanficReader:addToMainMenu(menu_items)
             showCommentDialog(nil)
         end
     end
+
+    menu_items.AO3_downloader_mark_later_read_work = {
+        text = "Toggle work mark for later / read",
+        sorting_hint = "main",
+        keep_menu_open = true,
+        callback = function()
+            local NetworkMgr = require("ui/network/manager")
+
+            if not NetworkMgr:isConnected() then
+                NetworkMgr:runWhenConnected()
+                return
+            end
+
+            local request_result = AO3DownloaderClient:markForLaterWork(self.current_fanfic.id, self.current_fanfic.markedForLater)
+
+            self.current_fanfic.markedForLater = not self.current_fanfic.markedForLater
+            DownloadedFanfics.update(self.current_fanfic,false)
+
+            if request_result.success then
+                UIManager:show(InfoMessage:new({
+                    text = self.current_fanfic.markedForLater and "Fanfic Marked for Later" or "Fanfic Marked as Read",
+                }))
+                return
+            end
+
+            UIManager:show(InfoMessage:new({
+                text = "Error: " .. request_result.error,
+            }))
+        end,
+    }
+
+    menu_items.AO3_downloader_subscribe_work = {
+        text = "Toggle work subscription",
+        sorting_hint = "main",
+        keep_menu_open = true,
+        callback = function()
+            local NetworkMgr = require("ui/network/manager")
+
+            if not NetworkMgr:isConnected() then
+                NetworkMgr:runWhenConnected()
+                return
+            end
+
+            local request_result = AO3DownloaderClient:setWorkSubscription(self.current_fanfic.id, self.current_fanfic.subscriptionID)
+            if request_result.success then
+                if request_result.subscription_id then
+                    self.current_fanfic.subscriptionID = request_result.subscription_id
+                else
+                    self.current_fanfic.subscriptionID = false
+                end
+                DownloadedFanfics.update(self.current_fanfic, false)
+
+                UIManager:show(InfoMessage:new({
+                    text = self.current_fanfic.subscriptionID and "Subscribed to Fanfic" or "Unsubscribed from Fanfic",
+                }))
+                return
+            end
+
+            UIManager:show(InfoMessage:new({
+                text = "Error: " .. request_result.error .. self.current_fanfic.subscriptionID,
+            }))
+        end,
+    }
+
+    menu_items.AO3_downloader_bookmarked_work = {
+        text = self.current_fanfic.bookmarkID and "Edit Bookmark" or "Bookmark Work",
+        sorting_hint = "main",
+        keep_menu_open = true,
+        callback = function ()
+            local NetworkMgr = require("ui/network/manager")
+            if not NetworkMgr:isConnected() then
+                NetworkMgr:runWhenConnected()
+                return
+            end
+
+            local MultiInputDialog = require("ui/widget/multiinputdialog")
+            local UIManager = require("ui/uimanager")
+            local _ = require("gettext")
+
+            local bookmark_input
+
+            local buttons = {
+                {
+                    text = _("Cancel"),
+                    id = "close",
+                    callback = function()
+                        UIManager:close(bookmark_input)
+                    end
+                },
+                {
+                    text = _(self.current_fanfic.bookmarkID and "Update" or "Create"),
+                    callback = function(touchmenu_instance)
+                        local fields = bookmark_input:getFields()
+
+                        local request_result = AO3DownloaderClient:updateBookmark(
+                            self.current_fanfic.id,
+                            self.current_fanfic.bookmarkID,
+                            "18388684",
+                            fields[1],
+                            fields[2],
+                            fields[3],
+                            fields[4] == "y" or fields[4] == "Y",
+                            fields[5] == "y" or fields[5] == "Y"
+                        )
+
+                        if request_result.success then
+                            local originalBMID = self.current_fanfic.bookmarkID
+
+                            if request_result.bookmark_id then
+                                self.current_fanfic.bookmarkID = request_result.bookmark_id
+                            end
+                            DownloadedFanfics.update(self.current_fanfic, false)
+
+                            UIManager:show(InfoMessage:new({
+                                text = originalBMID and "Updated Bookmark" or "Created Bookmark",
+                            }))
+
+                            return
+                        end
+
+                        UIManager:show(InfoMessage:new({
+                            text = "Error: " .. request_result.error,
+                        }))
+
+
+                        UIManager:close(bookmark_input)
+                    end
+                }
+            }
+
+            if self.current_fanfic.bookmarkID then
+                table.insert(buttons, {
+                    text = _("Delete"),
+                    id = "close",
+                    callback = function()
+
+                        local request_result = AO3DownloaderClient:deleteBookmark(self.current_fanfic.bookmarkID)
+
+                        if request_result.success then
+                            if request_result.bookmark_id then
+                                self.current_fanfic.bookmarkID = false
+                            end
+                            DownloadedFanfics.update(self.current_fanfic, false)
+
+                            UIManager:show(InfoMessage:new({
+                                text = "Deleted Bookmark",
+                            }))
+
+                            return
+                        end
+
+                        UIManager:show(InfoMessage:new({
+                            text = "Error: " .. request_result.error,
+                        }))
+
+
+                        UIManager:close(bookmark_input)
+                    end
+                })
+            end
+
+            bookmark_input = MultiInputDialog:new {
+                title = _(self.current_fanfic.bookmarkID and "Overwrite existing bookmark" or "Save a bookmark!"),
+                fields = {
+                    {
+                        hint = _("Notes")
+                    },
+                    {
+                        hint = _("Your tags (Comma Seperated)")
+                    },
+                    {
+                        hint = _("Add to collections (Comma Seperated)"),
+                    },
+                    {
+                        hint = _("Private bookmark (Y/N)"),
+                    },
+                    {
+                        hint = _("Rec (Y/N)"),
+                    },
+                },
+                buttons = {
+                    buttons
+                },
+            }
+            UIManager:show(bookmark_input)
+            bookmark_input:onShowKeyboard()
+
+        end
+    }
 end
 
 function FanficReader:initializeFromReaderUI(ui)

--- a/fanfic_reader.lua
+++ b/fanfic_reader.lua
@@ -8,6 +8,10 @@ local DownloadedFanfics = require("downloaded_fanfics")
 local AO3DownloaderClient = require("AO3_downloader_client")
 local InfoMessage = require("ui/widget/infomessage")
 local InputDialog = require("ui/widget/inputdialog")
+local ButtonDialog = require("ui/widget/buttondialog")
+
+local FFIUtil = require("ffi/util")
+local T = FFIUtil.template
 
 local FanficReader = {
     on_return_callback = nil,
@@ -92,6 +96,210 @@ function FanficReader:addToMainMenu(menu_items)
         self.input_dialog:onShowKeyboard()
     end
 
+    menu_items.AO3_manage_work = {
+        text = "Manage work",
+        sorting_hint = "main",
+        keep_menu_open = false,
+        callback = function()
+            local dialog
+            dialog = ButtonDialog:new({
+                title = T("Options for '%1'", self.current_fanfic.title),
+                buttons = { 
+                {
+                    {
+                        text = self.current_fanfic.markedForLater and "Mark as read" or "Mark for later",
+                        callback = function()
+                            local NetworkMgr = require("ui/network/manager")
+
+                            if not NetworkMgr:isConnected() then
+                                NetworkMgr:runWhenConnected()
+                                return
+                            end
+
+                            local request_result = AO3DownloaderClient:markForLaterWork(self.current_fanfic.id,
+                                self.current_fanfic.markedForLater)
+
+                            self.current_fanfic.markedForLater = not self.current_fanfic.markedForLater
+                            DownloadedFanfics.update(self.current_fanfic, false)
+
+                            if request_result.success then
+                                UIManager:show(InfoMessage:new({
+                                    text = self.current_fanfic.markedForLater and "Fanfic Marked for Later" or
+                                        "Fanfic Marked as Read",
+                                }))
+                            else
+                                UIManager:show(InfoMessage:new({
+                                    text = "Error: " .. request_result.error,
+                                }))
+                            end
+
+                            UIManager:close(dialog)
+                        end,
+                    }
+                    },
+                    {
+                        {
+                            text = self.current_fanfic.subscriptionID and "Unsubscribe from work" or "Subscribe to work",
+                            callback = function()
+                                local NetworkMgr = require("ui/network/manager")
+
+                                if not NetworkMgr:isConnected() then
+                                    NetworkMgr:runWhenConnected()
+                                    return
+                                end
+
+                                local request_result = AO3DownloaderClient:setWorkSubscription(self.current_fanfic.id,
+                                    self.current_fanfic.subscriptionID)
+                                if request_result.success then
+                                    if request_result.subscription_id then
+                                        self.current_fanfic.subscriptionID = request_result.subscription_id
+                                    else
+                                        self.current_fanfic.subscriptionID = false
+                                    end
+                                    DownloadedFanfics.update(self.current_fanfic, false)
+
+                                    UIManager:show(InfoMessage:new({
+                                        text = self.current_fanfic.subscriptionID and "Subscribed to Fanfic" or
+                                        "Unsubscribed from Fanfic",
+                                    }))
+                                else
+                                    UIManager:show(InfoMessage:new({
+                                        text = "Error: " .. request_result.error .. self.current_fanfic.subscriptionID,
+                                    }))
+                                end
+
+                                UIManager:close(dialog)
+                            end,
+                        }
+                    },
+                    {
+                        {
+                            text = self.current_fanfic.bookmarkID and "Edit Bookmark" or "Bookmark Work",
+                            callback = function ()
+                                local NetworkMgr = require("ui/network/manager")
+                                if not NetworkMgr:isConnected() then
+                                    NetworkMgr:runWhenConnected()
+                                    return
+                                end
+
+                                local MultiInputDialog = require("ui/widget/multiinputdialog")
+                                local UIManager = require("ui/uimanager")
+                                local _ = require("gettext")
+
+                                local bookmark_input
+
+                                local buttons = {
+                                    {
+                                        text = _("Cancel"),
+                                        id = "close",
+                                        callback = function()
+                                            UIManager:close(bookmark_input)
+                                        end
+                                    },
+                                    {
+                                        text = _(self.current_fanfic.bookmarkID and "Update" or "Create"),
+                                        callback = function()
+                                            local fields = bookmark_input:getFields()
+
+                                            local request_result = AO3DownloaderClient:updateBookmark(
+                                                self.current_fanfic.id,
+                                                self.current_fanfic.bookmarkID,
+                                                fields[1],
+                                                fields[2],
+                                                fields[3],
+                                                fields[4] == "y" or fields[4] == "Y",
+                                                fields[5] == "y" or fields[5] == "Y"
+                                            )
+
+                                            if request_result.success then
+                                                local originalBMID = self.current_fanfic.bookmarkID
+
+                                                if request_result.bookmark_id then
+                                                    self.current_fanfic.bookmarkID = request_result.bookmark_id
+                                                end
+                                                DownloadedFanfics.update(self.current_fanfic, false)
+
+                                                UIManager:show(InfoMessage:new({
+                                                    text = originalBMID and "Updated Bookmark" or "Created Bookmark",
+                                                }))
+
+                                                return
+                                            end
+
+                                            UIManager:show(InfoMessage:new({
+                                                text = "Error: " .. request_result.error,
+                                            }))
+
+
+                                            UIManager:close(bookmark_input)
+                                        end
+                                    }
+                                }
+
+                                if self.current_fanfic.bookmarkID then
+                                    table.insert(buttons, {
+                                        text = _("Delete"),
+                                        id = "close",
+                                        callback = function()
+
+                                            local request_result = AO3DownloaderClient:deleteBookmark(self.current_fanfic.bookmarkID)
+
+                                            if request_result.success then
+                                                self.current_fanfic.bookmarkID = false
+                                                DownloadedFanfics.update(self.current_fanfic, false)
+
+                                                UIManager:show(InfoMessage:new({
+                                                    text = "Deleted Bookmark",
+                                                }))
+
+                                                return
+                                            end
+
+                                            UIManager:show(InfoMessage:new({
+                                                text = "Error: " .. request_result.error,
+                                            }))
+
+                                            UIManager:close(bookmark_input)
+                                        end
+                                    })
+                                end
+
+                                bookmark_input = MultiInputDialog:new {
+                                    title = _(self.current_fanfic.bookmarkID and "Overwrite existing bookmark" or "Save a bookmark!"),
+                                    fields = {
+                                        {
+                                            hint = _("Notes")
+                                        },
+                                        {
+                                            hint = _("Your tags (Comma Seperated)")
+                                        },
+                                        {
+                                            hint = _("Add to collections (Comma Seperated)"),
+                                        },
+                                        {
+                                            hint = _("Private bookmark (Y/N)"),
+                                        },
+                                        {
+                                            hint = _("Rec (Y/N)"),
+                                        },
+                                    },
+                                    buttons = {
+                                        buttons
+                                    },
+                                }
+                                UIManager:show(bookmark_input)
+                                bookmark_input:onShowKeyboard()
+
+                                UIManager:close(dialog)
+
+                            end
+                        }
+                    }
+                },
+            })
+            UIManager:show(dialog)
+        end
+    }
     menu_items.AO3_downloader_kudos_work = {
         text = "Give kudos to work ♥",
         sorting_hint = "main",
@@ -144,190 +352,6 @@ function FanficReader:addToMainMenu(menu_items)
         end
     end
 
-    menu_items.AO3_downloader_mark_later_read_work = {
-        text = "Toggle work mark for later / read",
-        sorting_hint = "main",
-        keep_menu_open = true,
-        callback = function()
-            local NetworkMgr = require("ui/network/manager")
-
-            if not NetworkMgr:isConnected() then
-                NetworkMgr:runWhenConnected()
-                return
-            end
-
-            local request_result = AO3DownloaderClient:markForLaterWork(self.current_fanfic.id, self.current_fanfic.markedForLater)
-
-            self.current_fanfic.markedForLater = not self.current_fanfic.markedForLater
-            DownloadedFanfics.update(self.current_fanfic,false)
-
-            if request_result.success then
-                UIManager:show(InfoMessage:new({
-                    text = self.current_fanfic.markedForLater and "Fanfic Marked for Later" or "Fanfic Marked as Read",
-                }))
-                return
-            end
-
-            UIManager:show(InfoMessage:new({
-                text = "Error: " .. request_result.error,
-            }))
-        end,
-    }
-
-    menu_items.AO3_downloader_subscribe_work = {
-        text = "Toggle work subscription",
-        sorting_hint = "main",
-        keep_menu_open = true,
-        callback = function()
-            local NetworkMgr = require("ui/network/manager")
-
-            if not NetworkMgr:isConnected() then
-                NetworkMgr:runWhenConnected()
-                return
-            end
-
-            local request_result = AO3DownloaderClient:setWorkSubscription(self.current_fanfic.id, self.current_fanfic.subscriptionID)
-            if request_result.success then
-                if request_result.subscription_id then
-                    self.current_fanfic.subscriptionID = request_result.subscription_id
-                else
-                    self.current_fanfic.subscriptionID = false
-                end
-                DownloadedFanfics.update(self.current_fanfic, false)
-
-                UIManager:show(InfoMessage:new({
-                    text = self.current_fanfic.subscriptionID and "Subscribed to Fanfic" or "Unsubscribed from Fanfic",
-                }))
-                return
-            end
-
-            UIManager:show(InfoMessage:new({
-                text = "Error: " .. request_result.error .. self.current_fanfic.subscriptionID,
-            }))
-        end,
-    }
-
-    menu_items.AO3_downloader_bookmarked_work = {
-        text = self.current_fanfic.bookmarkID and "Edit Bookmark" or "Bookmark Work",
-        sorting_hint = "main",
-        keep_menu_open = true,
-        callback = function ()
-            local NetworkMgr = require("ui/network/manager")
-            if not NetworkMgr:isConnected() then
-                NetworkMgr:runWhenConnected()
-                return
-            end
-
-            local MultiInputDialog = require("ui/widget/multiinputdialog")
-            local UIManager = require("ui/uimanager")
-            local _ = require("gettext")
-
-            local bookmark_input
-
-            local buttons = {
-                {
-                    text = _("Cancel"),
-                    id = "close",
-                    callback = function()
-                        UIManager:close(bookmark_input)
-                    end
-                },
-                {
-                    text = _(self.current_fanfic.bookmarkID and "Update" or "Create"),
-                    callback = function(touchmenu_instance)
-                        local fields = bookmark_input:getFields()
-
-                        local request_result = AO3DownloaderClient:updateBookmark(
-                            self.current_fanfic.id,
-                            self.current_fanfic.bookmarkID,
-                            fields[1],
-                            fields[2],
-                            fields[3],
-                            fields[4] == "y" or fields[4] == "Y",
-                            fields[5] == "y" or fields[5] == "Y"
-                        )
-
-                        if request_result.success then
-                            local originalBMID = self.current_fanfic.bookmarkID
-
-                            if request_result.bookmark_id then
-                                self.current_fanfic.bookmarkID = request_result.bookmark_id
-                            end
-                            DownloadedFanfics.update(self.current_fanfic, false)
-
-                            UIManager:show(InfoMessage:new({
-                                text = originalBMID and "Updated Bookmark" or "Created Bookmark",
-                            }))
-
-                            return
-                        end
-
-                        UIManager:show(InfoMessage:new({
-                            text = "Error: " .. request_result.error,
-                        }))
-
-
-                        UIManager:close(bookmark_input)
-                    end
-                }
-            }
-
-            if self.current_fanfic.bookmarkID then
-                table.insert(buttons, {
-                    text = _("Delete"),
-                    id = "close",
-                    callback = function()
-
-                        local request_result = AO3DownloaderClient:deleteBookmark(self.current_fanfic.bookmarkID)
-
-                        if request_result.success then
-                            self.current_fanfic.bookmarkID = false
-                            DownloadedFanfics.update(self.current_fanfic, false)
-
-                            UIManager:show(InfoMessage:new({
-                                text = "Deleted Bookmark",
-                            }))
-
-                            return
-                        end
-
-                        UIManager:show(InfoMessage:new({
-                            text = "Error: " .. request_result.error,
-                        }))
-
-                        UIManager:close(bookmark_input)
-                    end
-                })
-            end
-
-            bookmark_input = MultiInputDialog:new {
-                title = _(self.current_fanfic.bookmarkID and "Overwrite existing bookmark" or "Save a bookmark!"),
-                fields = {
-                    {
-                        hint = _("Notes")
-                    },
-                    {
-                        hint = _("Your tags (Comma Seperated)")
-                    },
-                    {
-                        hint = _("Add to collections (Comma Seperated)"),
-                    },
-                    {
-                        hint = _("Private bookmark (Y/N)"),
-                    },
-                    {
-                        hint = _("Rec (Y/N)"),
-                    },
-                },
-                buttons = {
-                    buttons
-                },
-            }
-            UIManager:show(bookmark_input)
-            bookmark_input:onShowKeyboard()
-
-        end
-    }
 end
 
 function FanficReader:initializeFromReaderUI(ui)

--- a/fanfic_reader.lua
+++ b/fanfic_reader.lua
@@ -245,6 +245,7 @@ function FanficReader:addToMainMenu(menu_items)
 
                                             if request_result.success then
                                                 self.current_fanfic.bookmarkID = false
+                                                self.current_fanfic.bookmarkContent = nil
                                                 DownloadedFanfics.update(self.current_fanfic, false)
 
                                                 UIManager:show(InfoMessage:new({
@@ -267,19 +268,24 @@ function FanficReader:addToMainMenu(menu_items)
                                     title = _(self.current_fanfic.bookmarkID and "Overwrite existing bookmark" or "Save a bookmark!"),
                                     fields = {
                                         {
-                                            hint = _("Notes")
+                                            hint = _("Notes"),
+                                            text = self.current_fanfic.bookmarkContent and self.current_fanfic.bookmarkContent.notes or nil
                                         },
                                         {
-                                            hint = _("Your tags (Comma Seperated)")
+                                            hint = _("Your tags (Comma Seperated)"),
+                                            text = self.current_fanfic.bookmarkContent and self.current_fanfic.bookmarkContent.tags or nil
                                         },
                                         {
                                             hint = _("Add to collections (Comma Seperated)"),
+                                            text = self.current_fanfic.bookmarkContent and self.current_fanfic.bookmarkContent.collections or nil
                                         },
                                         {
                                             hint = _("Private bookmark (Y/N)"),
+                                            text = self.current_fanfic.bookmarkContent and (self.current_fanfic.bookmarkContent.private and "Y" or "N") or nil
                                         },
                                         {
                                             hint = _("Rec (Y/N)"),
+                                            text = self.current_fanfic.bookmarkContent and (self.current_fanfic.bookmarkContent.rec and "Y" or "N") or nil
                                         },
                                     },
                                     buttons = {

--- a/fanfic_reader.lua
+++ b/fanfic_reader.lua
@@ -239,7 +239,6 @@ function FanficReader:addToMainMenu(menu_items)
                                 if self.current_fanfic.bookmarkID then
                                     table.insert(buttons, {
                                         text = _("Delete"),
-                                        id = "close",
                                         callback = function()
 
                                             local request_result = AO3DownloaderClient:deleteBookmark(self.current_fanfic.bookmarkID)

--- a/fanfic_reader.lua
+++ b/fanfic_reader.lua
@@ -165,7 +165,7 @@ function FanficReader:addToMainMenu(menu_items)
                                     }))
                                 else
                                     UIManager:show(InfoMessage:new({
-                                        text = "Error: " .. request_result.error .. self.current_fanfic.subscriptionID,
+                                        text = "Error: " .. request_result.error .. (self.current_fanfic.subscriptionID or ""),
                                     }))
                                 end
 

--- a/main.lua
+++ b/main.lua
@@ -187,6 +187,9 @@ function Fanfic:DownloadFanfic(id)
         updated = request_result.work_metadata.updated,
         published = request_result.work_metadata.published,
         wordcount = request_result.work_metadata.wordcount,
+        markedForLater = request_result.work_metadata.markedForLater,
+        subscriptionID = request_result.work_metadata.subscriptionID,
+        bookmarkID = request_result.work_metadata.bookmarkID,
     }
 
     if fanfic.chapter_data then
@@ -270,6 +273,9 @@ function Fanfic:UpdateFanfic(fanfic)
     fanfic.updated = request_result.work_metadata.updated or fanfic.updated
     fanfic.published = request_result.work_metadata.published or fanfic.published
     fanfic.wordcount = request_result.work_metadata.wordcount or fanfic.wordcount
+    fanfic.markedForLater = request_result.work_metadata.markedForLater
+    fanfic.subscriptionID = request_result.work_metadata.subscriptionID
+    fanfic.bookmarkID = request_result.work_metadata.bookmarkID
 
     if #fanfic.chapter_data == 0 and not (request_result.work_metadata.chapterData == 0) then
         fanfic.read = nil

--- a/main.lua
+++ b/main.lua
@@ -190,6 +190,7 @@ function Fanfic:DownloadFanfic(id)
         markedForLater = request_result.work_metadata.markedForLater,
         subscriptionID = request_result.work_metadata.subscriptionID,
         bookmarkID = request_result.work_metadata.bookmarkID,
+        bookmarkContent = request_result.work_metadata.bookmarkContent
     }
 
     if fanfic.chapter_data then
@@ -276,6 +277,7 @@ function Fanfic:UpdateFanfic(fanfic)
     fanfic.markedForLater = request_result.work_metadata.markedForLater
     fanfic.subscriptionID = request_result.work_metadata.subscriptionID
     fanfic.bookmarkID = request_result.work_metadata.bookmarkID
+    fanfic.bookmarkContent = request_result.work_metadata.bookmarkContent
 
     if #fanfic.chapter_data == 0 and not (request_result.work_metadata.chapterData == 0) then
         fanfic.read = nil


### PR DESCRIPTION
Adds bookmark, mark for later and subscription buttons menu in the work alongside the comment and kudos buttons.

also exposes the status of a works bookmark, mark for later and subscription when viewing the details of a downloaded fic (below other tags, above stats)

Bookmarks are created from the users main psued id (the one thats the same as their username), but if overwriting a preexisting bookmark the id isn't needed so it stays as whatever psued originally created the bookmark.

