### PR TITLE
fix issue with chapter parsing when in full work mode

### DIFF
--- a/AO3_downloader_client.lua
+++ b/AO3_downloader_client.lua
@@ -1461,13 +1461,12 @@ function AO3WebParser:parseWorkPage(root)
     end
 
     if #chapterData == 0 then
-        local single_chapter_title = root:select(".chapter.preface.group > h3.title")[1]
-
-        if single_chapter_title then
-            local content = single_chapter_title:getcontent()
-            local chapter_title = string.match(content, "</a>:%s*(.+)") or "Chapter 1"
+        local chapter_title_elements = root:select(".chapter.preface.group > h3.title")
+        for _, chapter_title_element in pairs(chapter_title_elements) do
+            local content = chapter_title_element:getcontent()
+            local chapter_title = string.match(content, "</a>:%s*(.+)") or ("Chapter " .. (#chapterData + 1))
             local chapter_id = string.match(content, "/chapters/(%d+)")
-            table.insert(chapterData, { id = chapter_id, #chapterData + 1, name = "1. " .. chapter_title })
+            table.insert(chapterData, { id = chapter_id, #chapterData + 1, name = tostring(#chapterData + 1) .. ". " .. chapter_title })
         end
     end
 


### PR DESCRIPTION
If the ao3 user has the account option set that causes works to load the full work at once by default instead of chapter by chapter mode then the chapter selector element isn't available to be parsed, and the single chapter logic fires resulting in only the first chapter out of many appearing in the chapter menu.

Fixes the issue by just running the single chapter parse for every chapter title found in the work body