### PR TITLE
Add support for browsing a users collections

### DIFF
--- a/AO3_downloader_client.lua
+++ b/AO3_downloader_client.lua
@@ -590,6 +590,39 @@ function AO3DownloaderClient:getWorksFromSeries(series_id, page_no)
     }
 end
 
+function AO3DownloaderClient:getWorksFromCollection(collection_id, page_no)
+    logger.dbg("AO3Downloader.koplugin: Fetching works from collection ID: " .. tostring(collection_id) .. ", page no: " .. tostring(page_no))
+    page_no = page_no or 1
+    local url = T("%1/collections/%2/works?page=%3", getAO3URL(), collection_id, page_no)
+
+    local response_body = {}
+    local request = {
+        url = url,
+        method = "GET",
+        sink = ltn12.sink.table(response_body),
+    }
+
+    local request_result = HTTPQueryHandler:performHTTPRequest(request)
+
+    if not request_result.success then
+        return {
+            success = false,
+            error = T("Failed to fetch collection works. Status: %1", request_result.status or "unknown error"),
+        }
+    end
+
+    local html_body = table.concat(response_body)
+
+    local root = htmlparser.parse(html_body)
+
+    local works = AO3WebParser:parseWorkSearchResults(root)
+
+    return {
+        success = true,
+        works = works,
+    }
+end
+
 function AO3DownloaderClient:getWorksFromUserPage(username, pseud, catagory, fandom_id, page_no)
     local url
     if catagory == "gifts" then
@@ -687,6 +720,38 @@ function AO3DownloaderClient:getUserSeries(username, pseud, page_no)
     }
 end
 
+function AO3DownloaderClient:getUserCollections(username, page_no)
+    page_no = page_no or 1
+    logger.dbg("AO3Downloader.koplugin: Fetching collections for user: " .. tostring(username) .. ", page no: " .. tostring(page_no))
+    local url = T("%1/users/%2/collections?page=%3", getAO3URL(), username, page_no)
+
+    local response_body = {}
+    local request = {
+        url = url,
+        method = "GET",
+        sink = ltn12.sink.table(response_body),
+    }
+
+    local request_result = HTTPQueryHandler:performHTTPRequest(request)
+
+    if not request_result.success then
+        return {
+            success = false,
+            error = T("Failed to fetch user collections. Status: %1", request_result.status or "unknown error"),
+        }
+    end
+
+    local html_body = table.concat(response_body)
+
+    local root = htmlparser.parse(html_body)
+
+    local collections = AO3WebParser:parseUserCollectionsPage(root)
+
+    return {
+        success = true,
+        collections = collections,
+    }
+end
 
 function AO3DownloaderClient:getUserData(username, pseud)
     local url = T("%1/users/%2/pseuds/%3", getAO3URL(),username, pseud)
@@ -1186,6 +1251,82 @@ function AO3WebParser:parseUserSeriesPage(root)
     end
 
     return series_list
+end
+
+function AO3WebParser:parseUserCollectionsPage(root)
+    local collection_list = {}
+    local elements = root:select("li.collection")
+
+    local count = 1
+
+    for _, element in ipairs(elements) do
+        local titleElement = element:select(".heading > a:not([class])")[1]
+        if titleElement then
+
+            --works
+            --bookmarked items
+            --prompts
+            --challenges/subcollections
+
+            local href = titleElement.attributes.href
+            local id = href:match("/collections/([%w_-]+)")
+            local title = titleElement:getcontent()
+
+            local authorElements = element:select(".heading > a.owner")
+            local author_table = {}
+            for _, author in pairs(authorElements) do
+                table.insert(author_table, encodeHelper:parseToCodepoints(author:getcontent()))
+            end
+            authorElements = element:select(".heading > a.mod")
+            for _, author in pairs(authorElements) do
+                table.insert(author_table, encodeHelper:parseToCodepoints(author:getcontent()))
+            end
+            local author = #author_table > 0 and table.concat(author_table, ", ") or nil
+
+            local dateElement = element:select(".datetime")[1]
+
+            local date_posted = dateElement and encodeHelper:parseToCodepoints(dateElement:getcontent()) or ""
+
+            local tagElements = element:select(".tags > a.tag")
+            local tags = {}
+
+            for _, tagElement in pairs(tagElements) do
+                local content = tagElement:getcontent()
+                if content then
+                    table.insert(tags, encodeHelper:parseToCodepoints(content))
+                end
+            end
+
+            local typeElement = element:select("p.type")[1]
+            local type = typeElement:getcontent():gsub("^%s*(.-)%s*$", "%1") 
+
+            local summaryElement = element:select(".summary")[1]
+            local summary = (type and (type.." ") or "") .. (summaryElement and encodeHelper:parseToCodepoints(summaryElement:getcontent()
+                :gsub("<br%s*/?>", "\n") -- Replace <br> tags with new lines
+                :gsub("</p>", "\n\n") -- Add double new lines for paragraph breaks
+                :gsub("<[^>]+>", "") -- Remove other HTML tags
+                :gsub("^%s*(.-)%s*$", "%1") -- Trim whitespace) or ""
+            ))
+
+            local workCountElement = element:select("dd.works > a")[1]
+            local work_count = workCountElement and tonumber(workCountElement:getcontent():gsub(",", ""), 10) or 0
+
+            local collection = {
+                id = id,
+                title = title,
+                author = author,
+                date_posted = date_posted,
+                tags = tags,
+                summary = summary,
+                work_count = work_count,
+            }
+
+            table.insert(collection_list, count, collection)
+            count = count + 1
+        end
+    end
+
+    return collection_list
 end
 
 function AO3WebParser:parseWorkElement(element)

--- a/AO3_downloader_client.lua
+++ b/AO3_downloader_client.lua
@@ -1410,7 +1410,7 @@ function AO3WebParser:parseAccountHistory(root)
 end
 
 function AO3WebParser:parseWorkElement(element)
-    local titleElement = element:select(".heading > a")[1]
+    local titleElement = element:select("h4.heading > a")[1] or element:select("h4.heading")[1]
     local restrictedElement = element:select("img[title='Restricted']")[1]
     local authorElements = element:select(".heading > a[rel='author']")
     local giftElements = element:select(".heading > a[href$='/gifts']")
@@ -1434,7 +1434,7 @@ function AO3WebParser:parseWorkElement(element)
 
     if titleElement then
         -- Extract the work ID from the href attribute
-        local href = titleElement.attributes.href
+        local href = titleElement.attributes.href or ""
         local id = tonumber(href:match("/works/(%d+)")) -- Extract the numeric ID and convert to number
         local isRestricted = restrictedElement and true or false -- Set to true if restrictedElement exists, otherwise false
 

--- a/AO3_user_browser.lua
+++ b/AO3_user_browser.lua
@@ -151,11 +151,11 @@ function AO3UserBrowser:generateMenuTable()
         "Collections:",
         self.userData.total_collections,
         callback = function()
-            self:openFanficBrowserForCategory("collections", self.userData.total_collections, nil)
+            self:openUserCollectionsList()
         end,
     }
 
-    -- table.insert(kv_pairs, collections_item)
+    table.insert(kv_pairs, collections_item)
 
     local gifts_item = {
         "Gifted works:",
@@ -292,6 +292,63 @@ function AO3UserBrowser:openUserSeriesList()
         end
 
         self:GoDownInMenu("Series", series_menu_kv)
+    end
+end
+
+function AO3UserBrowser:openUserCollectionsList()
+    local success, collectionsList, getNextPage = self.Fanfic:getCollectionsFromUserPage(self.userData.username)  --
+    if success then
+        local collections_menu_kv = {}
+        table.insert(collections_menu_kv, {
+            "← Back to profile",
+            "",
+            separator = true,
+            callback = function()
+                self:GoUpInMenu()
+            end,
+        })
+        for __, collection in pairs(collectionsList) do
+            collections_menu_kv[#collections_menu_kv].separator = true
+
+            table.insert(collections_menu_kv, {
+                collection.title,
+                "",
+                callback = function()
+                    local success, collectionWorks, fetchNextPage = self.Fanfic:getWorksFromCollection(collection.id)
+                    if success == false then
+                        return
+                    end
+
+                    collectionWorks.total = collection.work_count or 0
+                    self.Fanfic:onShowFanficBrowser(collectionWorks, fetchNextPage)
+                end,
+                seperator = true,
+            })
+            table.insert(collections_menu_kv,{
+                "Tags:"
+                , table.concat(collection.tags, ", "),
+            })
+            table.insert(collections_menu_kv,{
+                "Work count:"
+                , collection.work_count,
+            })
+            table.insert(collections_menu_kv,{
+                "Author:"
+                , collection.author,
+            })
+            table.insert(collections_menu_kv,{
+                "Date:"
+                , collection.date_posted,
+            })
+            if collection.summary and collection.summary ~= "" then
+                table.insert(collections_menu_kv,{
+                    "Summary:"
+                    , collection.summary,
+                })
+            end
+        end
+
+        self:GoDownInMenu("Collections", collections_menu_kv)
     end
 end
 

--- a/fanficbrowser.lua
+++ b/fanficbrowser.lua
@@ -230,6 +230,10 @@ function FanficBrowser:generateTable(kv_pairs, ficResults, updateFanficCallback,
 end
 
 function FanficBrowser:showDownloadDialog(fanfic)
+    if not fanfic.id then 
+        return
+    end
+
     local confirmDialog
     confirmDialog = ButtonDialog:new({
         title = T("Would you like to download the work: %1 by %2?", fanfic.title, fanfic.author),

--- a/main.lua
+++ b/main.lua
@@ -528,6 +528,45 @@ function Fanfic:getSeriesFromUserPage(username, pseud)
 
 end
 
+function Fanfic:getCollectionsFromUserPage(username)
+    local NetworkMgr = require("ui/network/manager")
+    if not NetworkMgr:isConnected() then
+        NetworkMgr:runWhenConnected()
+        return false, {}
+    end
+    local works_result = AO3DownloaderClient:getUserCollections(username)
+    if not works_result.success then
+        UIManager:show(InfoMessage:new{
+            text = "Error: Failed to fetch works from user collections page: " .. (works_result.error or "Unknown error"),
+        })
+        return false
+    end
+
+    local currentPage = 1
+
+    local function getNextPage()
+        currentPage = currentPage + 1
+        local next_page_result = AO3DownloaderClient:getUserCollections(username, currentPage)
+        if not next_page_result.success then
+            currentPage = currentPage - 1
+            UIManager:show(InfoMessage:new{
+                text = "Error: Failed to fetch works from user collections page: " .. (next_page_result.error or "Unknown error"),
+            })
+            return {}
+        end
+
+        -- no more works to fetch
+        if #next_page_result.works == 0 then
+            currentPage = currentPage - 1
+            return {}
+        end
+
+        return  next_page_result.collections
+    end
+
+    return true, works_result.collections, getNextPage
+end
+
 function Fanfic:getWorksFromSeries(series_id)
     local NetworkMgr = require("ui/network/manager")
     if not NetworkMgr:isConnected() then
@@ -551,6 +590,47 @@ function Fanfic:getWorksFromSeries(series_id)
             currentpage = currentpage - 1
             UIManager:show(InfoMessage:new{
                 text = "Error: Failed to fetch works from series: " .. (next_page_result.error or "Unknown error"),
+            })
+            return {}
+        end
+
+        -- no more works to fetch
+        if #next_page_result.works == 0 then
+            currentpage = currentpage - 1
+            return {}
+        end
+
+        return  next_page_result.works
+
+    end
+
+    return true, works_result.works, fetchNextPage
+
+end
+
+function Fanfic:getWorksFromCollection(collection_id)
+    local NetworkMgr = require("ui/network/manager")
+    if not NetworkMgr:isConnected() then
+        NetworkMgr:runWhenConnected()
+        return false, {}
+    end
+    local works_result = AO3DownloaderClient:getWorksFromCollection(collection_id)
+    if not works_result.success then
+        UIManager:show(InfoMessage:new{
+            text = "Error: Failed to fetch works from collection: " .. (works_result.error or "Unknown error"),
+        })
+        return false
+    end
+
+    local currentpage = 1
+
+    local function fetchNextPage()
+        currentpage = currentpage + 1
+        local next_page_result = AO3DownloaderClient:getWorksFromCollection(collection_id, currentpage)
+        if not next_page_result.success then
+            currentpage = currentpage - 1
+            UIManager:show(InfoMessage:new{
+                text = "Error: Failed to fetch works from collection: " .. (next_page_result.error or "Unknown error"),
             })
             return {}
         end


### PR DESCRIPTION
Copy paste the series logic so that you can browse a list of collections belonging to a user and then view the works in that collection.

This PR doesn't solve the bug in the user pages openUserSeriesList / openUserCollectionsList functions that limit them to 20 entries max though, as openUserSeriesList does not have any logic for handling getting the next page and I haven't looked into that yet