### PR TITLE
Fix filter search crash on additional tag exclusion

### DIFF
--- a/custom_filter_menu.lua
+++ b/custom_filter_menu.lua
@@ -917,7 +917,7 @@ function CustomFilterMenu:WorkTagsSubmenu()
                 end
 
                 if self.filter.exclude_additional_tags then
-                    for __, tag in pairs(self.filter.additional_tags) do
+                    for __, tag in pairs(self.filter.exclude_additional_tags) do
                         table.insert(freemformStrings, "-" .. tag)
                     end
                 end


### PR DESCRIPTION
Fix iteration over wrong variable causing the filter menu to crash when leaving the additional tags section after excluding an additional tag, solves https://github.com/IntrovertedMage/AO3Downloader.koplugin/issues/41#issue-5250708805